### PR TITLE
Add PR Template as our default

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Because
+<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
+
+
+## This PR
+<!-- A bullet point list of one or more items describing the specific changes. -->
+
+
+## Issue
+<!--
+If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.
+
+If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX
+
+If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
+-->
+Closes #XXXXX
+
+## Additional Information
+<!-- Any other information about this PR, such as a link to a Discord discussion. -->
+


### PR DESCRIPTION
## Because
We do not have a default PR Template, which would be used on a staff repos, like top-meta or moderator

## This PR
* This is a slimmed down version of our PR Template
* The main checklist is not needed for staff contributions

## Issue
Related to https://github.com/TheOdinProject/curriculum/pull/24779

## Additional Information


