### PR TITLE
Feature: Add default Bug Report & Feature Request templates + issue config

### DIFF
--- a/ISSUE_TEMPLATE/bug_report.yaml
+++ b/ISSUE_TEMPLATE/bug_report.yaml
@@ -16,7 +16,7 @@ body:
       options:
         - label: I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
           required: true
-        - label: "The title of this issue follows the Bug: brief description of bug format, e.g. Bug: Lesson complete button does not update on click"
+        - label: "The title of this issue follows the `Bug: brief description of bug format`, e.g. `Bug: Lesson complete button does not update on click`"
           required: true
         - label: Would you like to work on this issue?
           required: false

--- a/ISSUE_TEMPLATE/bug_report.yaml
+++ b/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Report a issue or bug
+title: "Bug: <short description of bug>"
+assigness:
+  - nil
+body:
+  - type: markdown
+    attributes: 
+      value: |
+        Thanks for taking the time to report a bug! Please fill out these fields so your report can be reviewed - giving the right amount of detail makes it much easier for maintainers to process.
+
+        If you have any questions or are unsure about anything, don't be afraid to ask! The maintainers are here to help.
+  - type: checkboxes
+    id: contributing
+    attributes:
+      label: Checks
+      description: Please fill out the following checkboxes
+      options:
+        - label: I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
+          required: true
+        - label: "The title of this issue follows the Bug: brief description of bug format, e.g. Bug: Lesson complete button does not update on click"
+          required: true
+        - label: Would you like to work on this issue?
+          required: false
+  - type: textarea
+    id: suggested-changes
+    attributes:
+      label: Describe your suggestion
+      description: A description of your suggestion. You can provide screenshots or additional context if relevant
+      placeholder: ex 'There is a typo in the additional resource section - it should be wombat, not combat'
+    validations:
+      required: true
+  - type: input
+    id: link
+    attributes:
+      label: Location
+      description: A link to the relevant location, or the content that needs to be fixed. If not applicable, describe where to look for your suggestion
+      placeholder: ex. https://www.theodinproject.com/lessons/ruby-how-this-course-will-work
+    validations:
+      required: true
+  - type: input
+    id: discord-discussion
+    attributes:
+      label: (Optional) Discord discussion
+      description: If this has been discussed on Discord, provide a link to the thread/messages where it was discussed
+      placeholder: ex. odinite#1234
+    validations:
+      required: false
+  - type: input
+    id: contact
+    attributes:
+      label: (Optional) Discord Name
+      description: Optionally provide your discord name to help coordinate changes there if necessary
+      placeholder: ex. odinite#1234
+    validations:
+      required: false
+  - type: textarea
+    id: additional-comments
+    attributes:
+      label: (Optional) Additional Comments
+      description: "Anything else you'd like to cover"
+      placeholder: We ❤️ open source
+    validations:
+      required: false

--- a/ISSUE_TEMPLATE/bug_report.yaml
+++ b/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,8 +1,6 @@
 name: Bug report
 description: Report a issue or bug
 title: "Bug: <short description of bug>"
-assigness:
-  - nil
 body:
   - type: markdown
     attributes: 

--- a/ISSUE_TEMPLATE/bug_report.yaml
+++ b/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
-name: Bug report
-description: Report a issue or bug
+name: Bug Report
+description: Create a report to help us improve something that is not working correctly 
 title: "Bug: <short description of bug>"
 body:
   - type: markdown
@@ -41,7 +41,7 @@ body:
     attributes:
       label: (Optional) Discord discussion
       description: If this has been discussed on Discord, provide a link to the thread/messages where it was discussed
-      placeholder: ex. odinite#1234
+      placeholder: 
     validations:
       required: false
   - type: input

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Join the Discord Community
+    url: https://discord.gg/fbFCkYabZB
+    about: "Outside of GitHub, the Odin community lives on Discord. Join our server here"

--- a/ISSUE_TEMPLATE/feature_request.yaml
+++ b/ISSUE_TEMPLATE/feature_request.yaml
@@ -16,7 +16,7 @@ body:
       options:
         - label: I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
           required: true
-        - label: "The title of this issue follows the `Feature request: brief description of feature request` format, e.g. `Feature request: add dark mode"
+        - label: "The title of this issue follows the `Feature request: brief description of feature request` format, e.g. `Feature request: add dark mode`"
           required: true
         - label: Would you like to work on this issue?
           required: false

--- a/ISSUE_TEMPLATE/feature_request.yaml
+++ b/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,68 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for this project
+title: "Feature request: <short description of feature request>"
+body:
+  - type: markdown
+    attributes: 
+      value: |
+        Thank you for taking the time to submit a new feature request to The Odin Project. In order to get issues closed in a reasonable amount of time, you must include a baseline of information about the feature/enhancement you are proposing
+
+        If you have any questions or are unsure about anything, don't be afraid to ask! The maintainers are here to help.
+  - type: checkboxes
+    id: contributing
+    attributes:
+      label: Checks
+      description: Please fill out the following checkboxes
+      options:
+        - label: I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
+          required: true
+        - label: "The title of this issue follows the `Feature request: brief description of feature request` format, e.g. `Feature request: add dark mode"
+          required: true
+        - label: Would you like to work on this issue?
+          required: false
+  - type: textarea
+    id: suggested-feature
+    attributes:
+      label: Describe your suggestion
+      description: |
+        A clear and concise description of what the feature or enhancement is, including how it would be useful/beneficial or what problem(s) it would solve.
+
+        When suggesting an entirely new feature, it can help to provide a statement that follows the "When EVENT occurs, I want SOMETHING to happen, to achieve RESULT" format, e.g. "When I visit TOP after a long break, I want a button to be able to reset all of my progress at once, so I can start fresh." 
+      placeholder: ex 'There is a typo in the additional resource section - it should be wombat, not combat'
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: A list of checkbox items that explain the requirements needed to be met to resolve this request
+      placeholder: |
+        - [ ] A theme toggle is present on the dashboard
+        - [ ] Clicking the theme toggle changes between light and dark
+        - [ ] A user's theme choice persists after leaving the website
+    validations:
+      required: true
+  - type: input
+    id: discord-discussion
+    attributes:
+      label: (Optional) Discord discussion
+      description: If this has been discussed on Discord, provide a link to the thread/messages where it was discussed
+      placeholder: 
+    validations:
+      required: false
+  - type: input
+    id: contact
+    attributes:
+      label: (Optional) Discord Name
+      description: Optionally provide your discord name to help coordinate changes there if necessary
+      placeholder: ex. odinite#1234
+    validations:
+      required: false
+  - type: textarea
+    id: additional-comments
+    attributes:
+      label: (Optional) Additional Comments
+      description: "Anything else you'd like to cover"
+      placeholder: We ❤️ open source
+    validations:
+      required: false


### PR DESCRIPTION
## Because
- A longstanding todo is to add default issue templates


## This PR
- Adds a default issue config, which provides a Bug Report & Feature Request + a link to the TOP Discord server
- Adds Bug Report & Feature Request templates, both inspired by the ones in the curriculum repo and the main website repo, and heavily drawing language from there
  - Both of these use Github's issue form syntax, which provides a clear set of fields to fill in, instead of needing to use lots of commented out text to provide guidance
   - Both can be seen in action on https://github.com/Asartea/odin-test-repository, which contains a synched version of the proposed changes, as GitHub does not like issues on forks
