### PR TITLE
Fix: sync CONTRIBUTING.md with the version present on the TOP repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ The labels that get applied to issues and PRs in our repos have specific meaning
 ### Type Labels
 * **Accessibility**: Involves an accessibility feature or requires accessibility review
 * **Bug**: Involves something that isn't working as intended
-* **Chore**: Involves changes with no user-facing value, to the build process/internal tooling, refactors, etc. 
+* **Chore**: Involves changes with no user-facing value, to the build process/internal tooling, refactors, etc.
 * **Documentation**: Involves an update to the documentation
 * **Duplicate**: This issue/PR already exists
 * **Easy Fix**: Involves a minor fix such as grammar, syntax, etc.
@@ -61,14 +61,14 @@ The labels that get applied to issues and PRs in our repos have specific meaning
 
 ## How to Contribute
 
-**Simple Issues and Changes**: These don't have an overall significant impact on our repos. You can just open an issue or a PR in the appropriate repo rather than needing to bring it up on our Discord server. Simple issues and changes can include:
+**Simple Issues and Changes**: These don't have an overall significant impact on our repos. You can just open an issue or a PR in the appropriate repo. Simple issues and changes can include:
 
 * Typo or grammar fixes - "I noticed that this sentence in this lesson is using incorrect grammar."
 * Simple syntax errors - "This line of code is missing a closing element tag."
 * Clarifying questions - "This lesson says to use this syntax, but in a previous lesson we were told to use a different syntax. Which is correct?"
 * Other small-scale changes - "I think including an instruction about X could help minimize confusion at this step."
 
-**Significant Issues and Changes**: These will have a more significant impact on our repos, or require more work to be done in order to resolve the issue or implement the change. You should never submit a PR for a significant issue or change without first getting approval from maintainers, as we don't want your time and work to go to waste if your proposal isn't accepted. You can either go to our [suggestions-bugs Discord channel](https://discordapp.com/channels/505093832157691914/540903304046182425) to mention an issue or a proposed change, or you can simply open an issue in the appropriate repo and wait to receive a response. This channel can also be used to share a link to an issue or PR you have created if you haven't seen any activity on the actual issue/PR for a while, or to have a more real-time discussion. Just keep in mind that maintainers have busy lives - many with day jobs - and may not get to items on our repos immediately. 
+**Significant Issues and Changes**: These will have a more significant impact on our repos, or require more work to be done in order to resolve the issue or implement the change. You should never submit a PR for a significant issue or change without first getting approval from maintainers, as we don't want your time and work to go to waste if your proposal isn't accepted. You can either open an issue or a discussion in the appropriate repo and wait to receive a response. Keep in mind that maintainers have busy lives - many with day jobs - and may not get to items on our repos immediately.
 
 Significant issues and changes can include:
 
@@ -86,7 +86,7 @@ If you're new to contributing to open-source, or if you just want to make a real
 While working on an existing or a new lesson, you must follow our [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md) to ensure the layout and formatting is consistent across our curriculum.
 
 Before submitting a PR for an existing or a new lesson, you must use our [Lesson Preview Tool](https://www.theodinproject.com/lessons/preview) to ensure the lesson Markdown is correctly formatted and rendering properly.
-  
+
 <hr>
 
 #### [TOP Website Repo](https://github.com/TheOdinProject/theodinproject)
@@ -121,7 +121,7 @@ Before attempting to make any changes, be sure to read the following Wiki pages:
 
 ### Check Before Doing Anything
 
-It's important that you look through any open issues or PRs in a repo before attempting to submit a new issue or work on a change, regardless of the complexity. This will help avoid any duplicates from being made, as well as prevent more than one person working on the same thing at the same time.
+It's important that you look through any open [issues](https://github.com/TheOdinProject/theodinproject/issues) or [pull requests](https://github.com/TheOdinProject/theodinproject/pulls) in a repo before attempting to submit a new issue or work on a change, regardless of the complexity. This will help avoid any duplicates from being made, as well as prevent more than one person working on the same thing at the same time.
 
 If your proposal already exists in an open issue or PR, but you feel there are details missing, comment on the issue/PR to let those involved know of those missing details.
 
@@ -149,6 +149,10 @@ If you would like to work on an existing issue in a repo:
    * The title of the issue must follow the format described in the issue template.
    * If you would like to be assigned the issue you are creating, complete the applicable checkbox in the issue template. Note that this does not guarantee that you will be assigned the issue, but rather it lets maintainers know that you are interested.
    * The more information you are able to provide in your issue, the better.
+   * Ensure you create the issue in the right repo; some of the repos are:
+      * The [curriculum](https://github.com/TheOdinProject/curriculum/issues/new/choose) repo, for changes to the actual content of lessons.
+      * The [theodinproject](https://github.com/TheOdinProject/theodinproject/issues/new/choose) repo, for changes to the TOP website.
+      * The exercise repos: [javascript](https://github.com/TheOdinProject/javascript-exercises/issues/new/choose), [css](https://github.com/TheOdinProject/css-exercises/issues/new/choose), and [ruby](https://github.com/TheOdinProject/ruby-exercises/issues/new/choose)
 
 ### Setting Up Your Local Clone
 
@@ -163,7 +167,7 @@ Before you begin working on anything, make sure you follow these steps in order 
     git clone git@github.com:<your username>/<repo name>.git
     # Otherwise for HTTPS:
     git clone https://github.com/<your username>/<repo name>.git
-    
+
     # An example:
     git clone git@github.com:Odinson/css-exercises.git
     ```
@@ -175,7 +179,7 @@ Before you begin working on anything, make sure you follow these steps in order 
     git remote add upstream git@github.com:TheOdinProject/<repo name>.git
     # Otherwise for HTTPS:
     git remote add upstream https://github.com/TheOdinProject/<repo name>.git
-    
+
     # An example:
     git remote add upstream https://github.com/TheOdinProject/css-exercises.git
     ```
@@ -188,7 +192,7 @@ Once you have the repo forked and cloned, and the upstream remote has been set, 
 
     ```bash
     git checkout -b <your branch name>
-    
+
     # Some examples:
     git checkout -b flex_exercise_hints
     git checkout -b knowledge_check_updates
@@ -199,7 +203,7 @@ Once you have the repo forked and cloned, and the upstream remote has been set, 
 
    ```bash
    git commit -m "<your commit message>"
-   
+
    # An example:
    git commit -m "Update solution files"
    ```
@@ -210,7 +214,7 @@ Once you have the repo forked and cloned, and the upstream remote has been set, 
 
     ```bash
     git push origin <your branch name>
-    
+
     # An example:
     git push origin flex_exercises
     ```
@@ -219,9 +223,9 @@ Once you have the repo forked and cloned, and the upstream remote has been set, 
 
 1. After pushing your changes, go to your forked repo on GitHub and click the "Compare & pull request" button. If you have multiples of this button, be sure you click the one for the correct branch.
    * If you don't see this button, you can click the branch dropdown menu and then select the branch you just pushed from your local clone:
-   
+
       ![GitHub branch dropdown menu](https://user-images.githubusercontent.com/70952936/150646139-bc080c64-db57-4776-8db1-6525b7b47be2.jpg)
-   
+
    * Once you have switched to the correct branch on GitHub, click the "Contribute" dropdown and then click the "Open pull request" button.
 
 2. **Read the PR template in its entirety before filling it out and submitting a PR**. Not filling out the template correctly will delay a PR getting merged.
@@ -237,4 +241,4 @@ Once you have the repo forked and cloned, and the upstream remote has been set, 
       ![Reviewers section of GitHub's sidebar](https://user-images.githubusercontent.com/70952936/150647064-4fdd59d1-82a4-4f18-894d-0e43a5ee0ffb.jpg)
 
 ## Further Help
-Please let us know if you require any further help with any of the steps in this guide in our [suggestions-bugs Discord channel](https://discordapp.com/channels/505093832157691914/540903304046182425).
+Please let us know if you require any further help with any of the steps in this guide by creating an issue in the relevant repository. If you need help with creating an issue [GitHub has a guide on how to do so](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue). For questions not covered by this guide you can also join our [Discord](https://discord.com/invite/fbFCkYabZB).


### PR DESCRIPTION
## Because
- For reasons I'm not entirely clear on there are two different copies of CONTRIBUTING.md; the one in this repo and https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md, with the only difference as far as I can tell being that this one tends to get ignored and therefore lags behind in changes


## This PR
- Syncs the one in this repo to the version in the `theodinproject` repo, although I'll also file a seperate issue about why there are two in the first place


## Issue
Partly part of TheOdinProject/theodinproject#3892

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->

