### PR TITLE
Fix: change "fork this repo" to "fork the repo you would like to work on"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ If you would like to work on an existing issue in a repo:
 
 Before you begin working on anything, make sure you follow these steps in order to set up a clone on your local machine:
 
-1. Fork the repo you want to work on to your own GitHub account. If you don't know how to do so, follow the GitHub documentation on how to [fork a repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
+1. Fork the repo you would like to work on to your own GitHub account. If you don't know how to do so, follow the GitHub documentation on how to [fork a repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
 
 2. Clone the forked repo to your local machine with one of the commands below. Be sure the `<your username>` text is replaced with your actual GitHub username, and the `<repo name>` with the actual repo name. You can also read the GitHub documentation on [cloning a repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ If you would like to work on an existing issue in a repo:
 
 Before you begin working on anything, make sure you follow these steps in order to set up a clone on your local machine:
 
-1. Fork this repo to your own GitHub account. If you don't know how to do so, follow the GitHub documentation on how to [fork a repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
+1. Fork the repo you want to work on to your own GitHub account. If you don't know how to do so, follow the GitHub documentation on how to [fork a repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
 
 2. Clone the forked repo to your local machine with one of the commands below. Be sure the `<your username>` text is replaced with your actual GitHub username, and the `<repo name>` with the actual repo name. You can also read the GitHub documentation on [cloning a repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# The Odin Project Security Policy
+
+## Reporting a Vulnerability
+> [!NOTE]
+> We do not have a bug bounty program.
+
+The Odin Project team take all security vulnerabilities seriously. Thank you for improving the security of our open-source software. We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
+
+You can report security vulnerabilities by emailing The Odin Project team at theodinprojectcontact@gmail.com.
+We'll get back to you as soon as possible.
+
+


### PR DESCRIPTION
## Because
The wording "Fork this repo..." for step 1 under the Setting Up Your Local Clone section in the [contributing guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md#setting-up-your-local-clone) is confusing. The word "this" makes it seem like the instruction is referring to the current repo (i.e the repo that holds the contributing guide), but it is actually referring to the repo that is to be worked on.

## This PR
- Changed the word "this" to "the repo you would like to work on"

## Issue
Since this is a small and quick fix, I made a pull request instead of opening an issue.

## Additional Information
Link to Discord discussion regarding this fix is [here](https://discord.com/channels/505093832157691914/505093832157691916/1177691462322884658)